### PR TITLE
Update for PyMongo Version 4

### DIFF
--- a/geojson-mongo-import.py
+++ b/geojson-mongo-import.py
@@ -13,6 +13,7 @@
 #
 
 import argparse, urllib, json
+from datetime import datetime
 from pymongo import MongoClient, GEOSPHERE, InsertOne
 from pymongo.errors import (PyMongoError, BulkWriteError)
 
@@ -51,8 +52,10 @@ collection.create_index([("geometry", GEOSPHERE)])
 
 bulkArr = []
 for feature in geojson['features']:
+  # Note: comment out next two lines if input file does not contain timestamp field having proper format
+  # timestamp = feature['properties']['timestamp']
+  # feature['properties']['timestamp'] = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
   bulkArr.append( InsertOne(feature) )
-
 
 # execute bulk operation to the DB
 try:


### PR DESCRIPTION
Hi,

it seems like the script isn't working anymore since PyMongo removed the method <code>collection.initialize_unordered_bulk_op</code> (see [here](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-initialize-ordered-bulk-op-and-initialize-unordered-bulk-op-is-removed)). I updated the script to use the replacement method instead.  However, I didn't really look at the exception-part, so no idea if this is still working as intended or not.
My changes also include the parentheses update for python 3 (from [this](https://github.com/rtbigdata/geojson-mongo-import.py/pull/1) pull request).

Maybe this is helpful for anyone who comes across this (seemingly abandoned) script in 2022, like I did.
